### PR TITLE
Resolution of issue #81

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,8 @@ Async typeahead extends default configuration list for `typeahead`, by adding fe
         - `labelKey` `array` in this case array is a list of fields in original object, which are combined in a single string with a space separator
         - `labelKey` `object` with `fields` `array` of fields to use, `separator` string separator to use between fields 
     - `cleanAfterSelection` `boolean` clean selection after component was selected (default false)
+    - `overrideOptions` if true, the user can type any text in the input field (or select an option, then modify it), 
+    and it will be saved in the RJSF model (default false)
     - `mapping` `object` that maps selected object to schema object
 
 

--- a/src/TypeaheadField.js
+++ b/src/TypeaheadField.js
@@ -260,6 +260,10 @@ export class AsyncTypeaheadField extends BaseTypeaheadField {
       options: this.state.options,
     });
 
+    if (this.props.overrideOptions) {
+      typeConf.onInputChange = this.props.onChange;
+    }
+
     return (
       <div id={$id}>
         <DefaultLabel {...this.props} />
@@ -282,6 +286,7 @@ AsyncTypeaheadField.propTypes = {
         PropTypes.object,
       ]),
       cleanAfterSelection: PropTypes.bool,
+      overrideOptions: PropTypes.bool,
       search: PropTypes.func,
     }).isRequired,
   }),

--- a/src/TypeaheadField.js
+++ b/src/TypeaheadField.js
@@ -260,7 +260,7 @@ export class AsyncTypeaheadField extends BaseTypeaheadField {
       options: this.state.options,
     });
 
-    if (this.props.overrideOptions) {
+    if (asyncTypeahead.overrideOptions) {
       typeConf.onInputChange = this.props.onChange;
     }
 


### PR DESCRIPTION
This adds a new prop `overrideOptions` that allows manual entry/editing of options. By default this prop is false, to preserve backwards compatibility with previous versions.