### PR TITLE
EN-389 added validation before deleting from the Grid

### DIFF
--- a/playground/app/medications/uiSchema.js
+++ b/playground/app/medications/uiSchema.js
@@ -274,8 +274,9 @@ export default {
                 "isSelected"
               ],
               "filterField": "isSelected",
-              'actionCompletedIcon' : "glyphicon glyphicon-trash",
+              'actionCompletedIcon' : "glyphicon glyphicon-refresh",
               "actionCompletedClassName": "deleted-row",
+              "mandatoryField" : [ 'drugName' ]
             }
           },
           {

--- a/src/table/actionHeaderFactory.js
+++ b/src/table/actionHeaderFactory.js
@@ -2,21 +2,36 @@ import React from "react";
 
 function actionFactory(action, actionConfiguration, schema) {if (action === "update") {
   return (cell, row, enumObject, rowIndex, formData, onChange) => {
-    let newFormData = formData.slice(0);
+    let newFormData = formData.slice(0);   
     if (rowIndex != undefined) {
       newFormData.map(function(value, index){
         if (rowIndex === index){
-          if(actionConfiguration.fieldToUpdate !== undefined){
-            let update = [];
-            actionConfiguration.fieldToUpdate.map(
-              (fieldToUpdate) => {
-                if(schema[fieldToUpdate] !== undefined){
-                  if(schema[fieldToUpdate]["type"] === "boolean"){
-                    update[fieldToUpdate] = !value[fieldToUpdate];
-                  } // can add separate block for each type of input
-                  newFormData[index] =  Object.assign({},  value, update );
+          let actionToApply = 0; // 0 - update(soft delete), 1 - delete(hard delete)
+          let { mandatoryField = undefined, fieldToUpdate = undefined } = actionConfiguration;
+
+          if(mandatoryField !== undefined){
+            mandatoryField.map((mandatory) =>{
+                if(value[mandatory] === undefined || value[mandatory] === ""){
+                  actionToApply = 1;
                 }
-              });
+            });
+          }
+          if(actionToApply === 0){ // just updating the Column
+            if(fieldToUpdate !== undefined){
+              let update = [];
+              fieldToUpdate.map(
+                (fieldToUpdate) => {
+                  if(schema[fieldToUpdate] !== undefined){
+                    if(schema[fieldToUpdate]["type"] === "boolean"){
+                      update[fieldToUpdate] = !value[fieldToUpdate];
+                    } // can add separate block for each type of input
+                    newFormData[index] =  Object.assign({},  value, update );
+                  }
+                });
+            }
+          }else if(actionToApply === 1){ //Hard delete the row
+            newFormData.splice(rowIndex, 1);
+            onChange(newFormData);   
           }
         }
       });


### PR DESCRIPTION
Added validation for soft delete on the Boostrap table.

before soft delete , it will validate the row's column weather the row have all the mandatory column field has been filled or not, if not means action will be the hard delete otherwise soft delete only.

modified the Icon for the deleted row trash to refresh(revert the deleted option)