### PR TITLE
EN-124 ReactDatePicker Month-Year navigation

### DIFF
--- a/playground/style.css
+++ b/playground/style.css
@@ -46,8 +46,8 @@
 .DayPicker-NavButton {
   position: absolute;
   cursor: pointer;
-  top: 1rem;
-  right: 1.5rem;
+  top: 1.5rem;
+  right: 0.5rem;
   margin-top: 2px;
   color: #8b9898;
   width: 1.25rem;


### PR DESCRIPTION
added Year-Month Navigation into the ReactDatePicker using captionElement property.
save the formdata on DayChange and yearMonthChange. 