### PR TITLE
Formatting the Bootsarp table column with array Type

### DIFF
--- a/src/table/columnHeadersFactory.js
+++ b/src/table/columnHeadersFactory.js
@@ -181,6 +181,8 @@ const columnHeadersFromSchema = (schema, uiSchema) => {
 };
 
 export function overrideColDataFormat(colConf, fieldSchema, formData) {
+
+  console.log("sdfasdfasdfasdf--=-=-=-");
   if (typeof colConf.dataFormat === "string" && fieldSchema.type === "object") {
     const { dataField, dataFormat: field } = colConf;
     colConf.dataFormat = function(cell, row) {
@@ -209,6 +211,29 @@ export function overrideColDataFormat(colConf, fieldSchema, formData) {
     };
     colConf.dataFormat.bind(this);
   }
+  else if (
+    colConf.field !== undefined &&
+     colConf.field === "asyncTypeahead"){ //Only handle Type head with Array 
+      if (fieldSchema.type === "array"){
+  
+      const { dataField=false, uiSchema:{ asyncTypeahead: { arrayItemIndicator="glyphicon glyphicon-record" } } } = colConf;
+       colConf.dataFormat = function(cell, row) {
+         let displayData = '';
+         if (dataField){
+           if ( cell !== undefined && Object.keys(cell).length >0){
+             Object.keys(cell).map((item)=>{
+                 displayData += `<i class='${arrayItemIndicator}'></i>${cell[item][dataField]}  `;                
+             });
+           }
+         } else {
+           displayData  ="Mapping Name not available";
+         }
+         return displayData;
+         
+       };
+       colConf.dataFormat.bind(this);
+      }     
+    }
 }
 
 const overrideColEditable = (colConf, fieldSchema, fields) => {


### PR DESCRIPTION
Added logic to handle the Array of value in the in the table column- Typehead can choose multiple values and saved in the array of data. 

uischema Should be 
   {
            dataField: "username",
            enableHelpText: true,
            field: "asyncTypeahead",
            uiSchema: {
              "ui:field": "asyncTypeahead",
              "asyncTypeahead": {
                "placeholder": "Type to search...",
                "url": "https://jsonplaceholder.typicode.com/users",
                "bodyContainer": true,
              
                "mapping": {
                  username : "username"


                },
                arrayItemIndicator : "glyphicon glyphicon-record",
                "labelKey": "username",
                "minLength": 2,
                multiple:true
              }
            }