### PR TITLE
Removed Dropdown Adjustement

### DIFF
--- a/src/helpers/shortkey/suggestion/index.js
+++ b/src/helpers/shortkey/suggestion/index.js
@@ -134,9 +134,9 @@ function getSuggestionComponent() {
       } else {
         left = 15;
       }
-      if (editorRect.bottom < dropdownRect.bottom) {
-        bottom = 0;
-      }
+      // if (editorRect.bottom < dropdownRect.bottom) {
+      //   bottom = 0;
+      // }
       this.setState({
         // eslint-disable-line react/no-did-mount-set-state
         style: { left, right, bottom },


### PR DESCRIPTION
This removed the dropdown from moving up if the editor doesn't have space to display the dropdown. 

Since our RTE always expands, we can always display suggestions going down.